### PR TITLE
apply patches applied after copying llvmPackages_9

### DIFF
--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -43,17 +43,17 @@ let
 
     llvm-manpages = lowPrio (tools.llvm.override {
       enableManpages = true;
-      python = pkgs.python3;  # don't use python-boot
+      python3 = pkgs.python3;  # don't use python-boot
     });
 
     clang-manpages = lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
-      python = pkgs.python3;  # don't use python-boot
+      python3 = pkgs.python3;  # don't use python-boot
     });
 
     lldb-manpages = lowPrio (tools.lldb.override {
       enableManpages = true;
-      python = pkgs.python3;  # don't use python-boot
+      python3 = pkgs.python3;  # don't use python-boot
     });
 
     libclang = tools.clang-unwrapped.lib;


### PR DESCRIPTION
I tested them on nixos, please test on darwin. This should bring llvmPackages_10 up to date regarding packaging.