### PR TITLE
made problematic substituteInPlace to only run on non-darwin system

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm.nix
+++ b/pkgs/development/compilers/llvm/10/llvm.nix
@@ -136,6 +136,8 @@ in stdenv.mkDerivation (rec {
   + optionalString enableSharedLibraries ''
     moveToOutput "lib/libLLVM-*" "$lib"
     moveToOutput "lib/libLLVM${stdenv.hostPlatform.extensions.sharedLibrary}" "$lib"
+  ''
+  + optionalString (enableSharedLibraries && (!stdenv.isDarwin)) ''
     substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
       --replace "\''${_IMPORT_PREFIX}/lib/libLLVM-" "$lib/lib/libLLVM-"
   ''


### PR DESCRIPTION
from my comment on [nixpkgs#78482](https://github.com/NixOS/nixpkgs/pull/78482)
> I had another look at the substituteStream-warning you get. I believe we can run the problematic substituion only on non-darwin devices. While I don't know exactly how thefile is generated or how darwin handles shared librries, the substituteInPlace that is only run on darwin seems to have the same same function.
> To test this, could you look into the lib output of llvm and check whether all files called libLLVM-* are symlinks to libLLVM.dylib. If this is the case the warning is no problem.