### PR TITLE
llvmPackages_11.compiler-rt: enable support for i486 i586 i686

### DIFF
--- a/pkgs/development/compilers/llvm/11/compiler-rt-X86-support-extension.patch
+++ b/pkgs/development/compilers/llvm/11/compiler-rt-X86-support-extension.patch
@@ -1,0 +1,23 @@
+diff --git a/lib/builtins/CMakeLists.txt b/lib/builtins/CMakeLists.txt
+index 3a66dd9c3fb..7efc85d9f9f 100644
+--- a/lib/builtins/CMakeLists.txt
++++ b/lib/builtins/CMakeLists.txt
+@@ -301,6 +301,10 @@ if (NOT MSVC)
+     i386/umoddi3.S
+   )
+ 
++  set(i486_SOURCES ${i386_SOURCES})
++  set(i586_SOURCES ${i386_SOURCES})
++  set(i686_SOURCES ${i386_SOURCES})
++
+   if (WIN32)
+     set(i386_SOURCES
+       ${i386_SOURCES}
+@@ -608,6 +612,7 @@ else ()
+   endif()
+ 
+   foreach (arch ${BUILTIN_SUPPORTED_ARCH})
++      message("arch: ${arch}")
+     if (CAN_TARGET_${arch})
+       # For ARM archs, exclude any VFP builtins if VFP is not supported
+       if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")

--- a/pkgs/development/compilers/llvm/11/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/11/compiler-rt.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
+    ./compiler-rt-X86-support-extension.patch # Add support for i486 i586 i686 by reusing i386 config
   ]# ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
     ++ stdenv.lib.optional stdenv.hostPlatform.isAarch32 ./compiler-rt-armv7l.patch;
 


### PR DESCRIPTION
Fixes the problem found in https://github.com/NixOS/nixpkgs/pull/99984.
The patch adds the required variables and should result in the same behavior as in the nixpkgs-llvm11. It essentially forces to use i386 buildins when using i486, i586 or i686, which are not supported.

It builds for x86_64 and i686 on my machine.